### PR TITLE
Fix link to custom lang definitions in Basic Usage

### DIFF
--- a/docs/basic-usage/index.html
+++ b/docs/basic-usage/index.html
@@ -206,7 +206,7 @@ captures the comment and string)</p>
 makes reasonable guesses for your language based on file extension. You can also
 force a particular matcher with a command line option, see the <a href="cheat-sheet#select-the-language-to-parse">Quick Reference</a>.
 And, you can always fall back to a generic matcher for files or languages that
-are not explicitly supported. You can find out more about <a href="http://localhost:3000/docs/advanced-usage#custom-language-definitions">language support and extension</a>.</p>
+are not explicitly supported. You can find out more about <a href="advanced-usage#custom-language-definitions">language support and extension</a>.</p>
 <p>Note that if we tried to use a regex above, our pattern would need to understand
 that <code>/* */</code> delineates comments, otherwise it would get confused by the
 parenthesis inside! The same problem comes up for the string literal argument,


### PR DESCRIPTION
It was linked to localhost. Changed to relative link.