### PR TITLE
Add instructions to use Docker from command line

### DIFF
--- a/website/docs/get-started.md
+++ b/website/docs/get-started.md
@@ -28,6 +28,12 @@ table tr:nth-child(2n) {
 
 Or [build from source](#build-from-source). Having trouble? Ask in [Gitter](https://gitter.im/comby-tools/community) or [create an issue on GitHub](https://github.com/comby-tools/comby/issues/new/choose).
 
+To make the command `comby` available to the system, you can create a script in bin containing
+```
+#!/usr/bin/env bash
+docker run --volume $PWD:/pwd --workdir="/pwd" -it comby/comby "$@"
+```
+
 ### Check your installation
 
 Run this in your terminal to check that things are working:

--- a/website/docs/get-started.md
+++ b/website/docs/get-started.md
@@ -28,13 +28,12 @@ table tr:nth-child(2n) {
 
 Or [build from source](#build-from-source). Having trouble? Ask in [Gitter](https://gitter.im/comby-tools/community) or [create an issue on GitHub](https://github.com/comby-tools/comby/issues/new/choose).
 
-To make the command `comby` available to the system, you can create a script in bin containing
-```
+Tip: If you're using the `comby` docker image, you can add a `comby` command to your terminal by adding a script like this to a directory in your `PATH` (e.g., `/usr/local/bin`):
+```bash
 #!/usr/bin/env bash
 docker run --volume $PWD:/pwd --workdir="/pwd" -it comby/comby "$@"
 ```
 where `docker` can also be replaced by `podman`.
-
 ### Check your installation
 
 Run this in your terminal to check that things are working:

--- a/website/docs/get-started.md
+++ b/website/docs/get-started.md
@@ -33,6 +33,7 @@ To make the command `comby` available to the system, you can create a script in 
 #!/usr/bin/env bash
 docker run --volume $PWD:/pwd --workdir="/pwd" -it comby/comby "$@"
 ```
+where `docker` can also be replaced by `podman`.
 
 ### Check your installation
 


### PR DESCRIPTION
I'm on NixOS and found it quite difficult to get comby. This PR makes a suggestion for the documentation. Feel free to close it if you don't like the suggestion.